### PR TITLE
Bump stylus to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,23 +3,26 @@
   "author": "Owen Barnes <owen@socketstream.com>",
   "maintainer": "Paul Jensen <paul@socketstream.com>",
   "description": "Stylus (CSS) wrapper for SocketStream 0.3",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "./wrapper.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/socketstream/ss-stylus"
   },
   "contributors": [
-    "Robert Hall (americanYak on Github)",
+    "Robert Hall (americanYak and arxpoetica on Github)",
     "Christian Sterzl (Waxolunist on Github)",
     "David Rosen (drosen0 on Github)",
-    "Simon Lang (captainclam on Github)"
+    "Simon Lang (captainclam on Github)",
+    "Andy Melnikov (nponeccop on Github)",
+    "Lou Huang (louh on GitHub)",
+    "Kirill Chernyshov (DeLaGuardo on GitHub)"
   ],
   "engines": {
     "node": ">= 0.6.0"
   },
   "dependencies": {
-    "stylus": "0.50.0"
+    "stylus": "0.54.7"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
also added missing contributors, and bumped ss-stylus version

This is a part of my effort to release Socketstream 0.4.6: 

https://github.com/socketstream/socketstream/issues/619
https://github.com/socketstream/socketstream/pull/620